### PR TITLE
Remove "Type '/' for commands"

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,4 @@ documentation](https://github.com/notion-enhancer/notion-enhancer/blob/master/TW
 * [Minify breadcrumbs and topbar buttons](minify%20breadcrumbs%20and%20topbar%20buttons.md)
 * [Remove arrows on linked pages and databases](remove%20arrows%20on%20linked%20pages%20and%20databases.md)
 * [Smaller page icons](smaller%20page%20icons.md)
+* [Remove "Type '/' for commands" hint](remove%20type%20for%20commands.md)

--- a/remove type for commands.md
+++ b/remove type for commands.md
@@ -8,11 +8,11 @@
 
 _before tweak_
 
-![before tweak]()
+![before tweak](https://user-images.githubusercontent.com/18431607/99712639-67ddc880-2ab4-11eb-8f34-a77455829c34.png)
 
 _after tweak_
 
-![after tweak]()
+![after tweak](https://user-images.githubusercontent.com/18431607/99712658-6dd3a980-2ab4-11eb-8654-d05585c50ca3.png)
 
 ## css
 

--- a/remove type for commands.md
+++ b/remove type for commands.md
@@ -1,0 +1,24 @@
+# Remove "Type '/' for commands"
+
+**last tested/working:** Nov 19, 2020
+
+**author(s):** [@Adambl4](https://github.com/Adambl4)
+
+> Remove "Type '/' for commands"
+
+_before tweak_
+
+![before tweak]()
+
+_after tweak_
+
+![after tweak]()
+
+## css
+
+```css
+/* ========== REMOVE TYPE FOR COMMANDS ========== */
+[contenteditable]:empty:before {
+  display: none !important;
+}
+```


### PR DESCRIPTION
# Remove "Type '/' for commands"

**last tested/working:** Nov 19, 2020

**author(s):** [@Adambl4](https://github.com/Adambl4)

> Remove "Type '/' for commands"

_before tweak_

![before tweak](https://user-images.githubusercontent.com/18431607/99712639-67ddc880-2ab4-11eb-8f34-a77455829c34.png)

_after tweak_

![after tweak](https://user-images.githubusercontent.com/18431607/99712658-6dd3a980-2ab4-11eb-8654-d05585c50ca3.png)

## css

```css
/* ========== REMOVE TYPE FOR COMMANDS ========== */
[contenteditable]:empty:before {
  display: none !important;
}
```