### PR TITLE
tweaks: hide callout icon and hide new page button

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,5 @@ if you are attempting to customise the web client, the css previously used for t
 * [Sticky table/list row](tweaks/sticky%20table%20list%20row.md)
 * [Table columns below 100px](tweaks/table%20columns%20below%20100px.md)
 * [Hide plus table column](tweaks/hide%20plus%20table%20column.md)
+* [Hide callout icon](https://github.com/admiraldus/tweaks/blob/dev/tweaks/hide%20callout%20icon.md)
+* [Hide new page button](https://github.com/admiraldus/tweaks/blob/dev/tweaks/hide%20new%20page%20button.md)

--- a/tweaks/hide callout icon.md
+++ b/tweaks/hide callout icon.md
@@ -1,0 +1,25 @@
+# Hide callout icon
+
+**last tested/working:** Dec 5, 2020
+
+**author(s):** [@admiraldus](https://github.com/admiraldus)
+
+<table border="0">
+ <tr>
+    <td><i>before tweak</i></td>
+    <td><i>after tweak</i></td>
+ </tr>
+ <tr>
+    <td><img alt="before tweak" src="https://i.imgur.com/VYhyPmZ.png"></td>
+    <td><img alt="after tweak" src="https://i.imgur.com/Qg1pOqe.png"></td>
+ </tr>
+</table>
+
+## css
+
+```css
+/* ========== HIDE CALLOUT ICON ========== */
+.notion-selectable.notion-callout-block .notion-record-icon {
+  display: none !important;
+}
+```

--- a/tweaks/hide new page button.md
+++ b/tweaks/hide new page button.md
@@ -1,0 +1,25 @@
+# Hide new page button
+
+**last tested/working:** Dec 5, 2020
+
+**author(s):** [@admiraldus](https://github.com/admiraldus)
+
+<table border="0">
+ <tr>
+    <td><i>before tweak</i></td>
+    <td><i>after tweak</i></td>
+ </tr>
+ <tr>
+    <td><img alt="before tweak" src="https://i.imgur.com/ghJsn6f.png"></td>
+    <td><img alt="after tweak" src="https://i.imgur.com/SXnATRd.png"></td>
+ </tr>
+</table>
+
+## css
+
+```css
+/* ========== HIDE NEW PAGE BUTTON ========== */
+.notion-sidebar > :nth-child(7) {
+  display: none !important;
+}
+```


### PR DESCRIPTION
- add 2 new tweaks
- update list of tweaks
# Hide callout icon

**last tested/working:** Dec 5, 2020

**author(s):** [@admiraldus](https://github.com/admiraldus)

<table border="0">
 <tr>
    <td><i>before tweak</i></td>
    <td><i>after tweak</i></td>
 </tr>
 <tr>
    <td><img alt="before tweak" src="https://i.imgur.com/VYhyPmZ.png"></td>
    <td><img alt="after tweak" src="https://i.imgur.com/Qg1pOqe.png"></td>
 </tr>
</table>

## css

```css
/* ========== HIDE CALLOUT ICON ========== */
.notion-selectable.notion-callout-block .notion-record-icon {
  display: none !important;
}
```
# Hide new page button

**last tested/working:** Dec 5, 2020

**author(s):** [@admiraldus](https://github.com/admiraldus)

<table border="0">
 <tr>
    <td><i>before tweak</i></td>
    <td><i>after tweak</i></td>
 </tr>
 <tr>
    <td><img alt="before tweak" src="https://i.imgur.com/ghJsn6f.png"></td>
    <td><img alt="after tweak" src="https://i.imgur.com/SXnATRd.png"></td>
 </tr>
</table>

## css

```css
/* ========== HIDE NEW PAGE BUTTON ========== */
.notion-sidebar > :nth-child(7) {
  display: none !important;
}
```