### PR TITLE
Add Fira Math css tweak snippet

### DIFF
--- a/tweaks/fira math.md
+++ b/tweaks/fira math.md
@@ -1,0 +1,15 @@
+# Fira Math
+
+**last tested/working:** Oct 12, 2021 8:40 AM
+
+**author(s)**: [@mtoohey31](https://github.com/mtoohey31)
+
+## css
+
+```css
+@import url("https://firamath.github.io/css/firamath.css");
+
+.katex {
+  font-family: "Fira Math" !important;
+}
+```


### PR DESCRIPTION
Here's the PR requested in [this comment](https://github.com/notion-enhancer/notion-enhancer/issues/404#issuecomment-937460725), I did a little more testing and it turns out that it's simpler than I thought it was. I couldn't find an official hosting url for the font so this snippet currently loads things from the Fira Math website.