### PR TITLE
tweaks' readme linking fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,5 +57,5 @@ if you are attempting to customise the web client, the css previously used for t
 * [Sticky table/list row](tweaks/sticky%20table%20list%20row.md)
 * [Table columns below 100px](tweaks/table%20columns%20below%20100px.md)
 * [Hide plus table column](tweaks/hide%20plus%20table%20column.md)
-* [Hide callout icon](https://github.com/admiraldus/tweaks/blob/dev/tweaks/hide%20callout%20icon.md)
-* [Hide new page button](https://github.com/admiraldus/tweaks/blob/dev/tweaks/hide%20new%20page%20button.md)
+* [Hide callout icon](https://github.com/notion-enhancer/tweaks/blob/main/tweaks/hide%20callout%20icon.md)
+* [Hide new page button](https://github.com/notion-enhancer/tweaks/blob/main/tweaks/hide%20new%20page%20button.md)


### PR DESCRIPTION
Fixed Hide Callout Icon and Hide New Page Button links which was redirecting to a 404 Error page instead of their readme.